### PR TITLE
fix(android): JSONException out of range (#1)

### DIFF
--- a/src/android/NativeAudio.java
+++ b/src/android/NativeAudio.java
@@ -81,7 +81,12 @@ public class NativeAudio extends CordovaPlugin implements AudioManager.OnAudioFo
                 AssetManager am = ctx.getResources().getAssets();
                 AssetFileDescriptor afd = am.openFd(fullPath);
 
-                String streamType = data.getString(5);
+                String streamType;
+                if (data.length() <= 5) {
+                  streamType = "music";
+                } else {
+                  streamType = data.getString(5);
+                }
 
                 NativeAudioAsset asset = new NativeAudioAsset(
                         afd, voices, (float) volume, streamType);

--- a/src/android/NativeAudio.java
+++ b/src/android/NativeAudio.java
@@ -81,12 +81,7 @@ public class NativeAudio extends CordovaPlugin implements AudioManager.OnAudioFo
                 AssetManager am = ctx.getResources().getAssets();
                 AssetFileDescriptor afd = am.openFd(fullPath);
 
-                String streamType;
-                if (data.length() <= 5) {
-                  streamType = "music";
-                } else {
-                  streamType = data.getString(5);
-                }
+                String streamType = data.optString(5);
 
                 NativeAudioAsset asset = new NativeAudioAsset(
                         afd, voices, (float) volume, streamType);


### PR DESCRIPTION
When using preloadSimple the argument for streamType is
not present and this is raising the exception.

Closes #1